### PR TITLE
Allow updates to data directory to be reflected on next slide load

### DIFF
--- a/wsi_service/simple_mapper.py
+++ b/wsi_service/simple_mapper.py
@@ -102,7 +102,7 @@ class SimpleMapper:
         return list(self.case_map.values())
 
     def get_slides(self, case_id):
-        self.load()
+        self.refresh()
         if case_id not in self.case_map:
             raise HTTPException(status_code=404, detail=f"Case with case_id {case_id} does not exist")
         slide_data = []


### PR DESCRIPTION
changing self.load() to self.refresh() scans the data directory before checking if the slide_id is valid - which shouldn't add much server load, but means that any new slides are available as soon as they're added to a folder.