### PR TITLE
add DICOM support to PathsMapper, fix wsidicom plugin

### DIFF
--- a/wsi_service/paths_mapper.py
+++ b/wsi_service/paths_mapper.py
@@ -38,16 +38,16 @@ class PathsMapper(BaseMapper):
             case_id = f"{context}/{d}"
             case_path = os.path.join(abs_context_path, d)
 
-            # If the directory itself is a supported format (e.g. DICOM),
-            # treat it as a slide rather than a case directory
             if is_supported_format(case_path):
-                slide_ids = [case_id]
-            else:
-                slide_ids = []
-                for file in os.listdir(case_path):
-                    absfile = os.path.join(case_path, file)
-                    if (os.path.isfile(absfile) or os.path.isdir(absfile)) and is_supported_format(absfile):
-                        slide_ids.append(f"{case_id}/{file}")
+                # Slide directory (e.g. DICOM) appears as a slide in the parent case, not as a case itself.
+                continue
+
+            # Regular case directory
+            slide_ids = []
+            for file in os.listdir(case_path):
+                absfile = os.path.join(case_path, file)
+                if is_supported_format(absfile):
+                    slide_ids.append(f"{case_id}/{file}")
 
             cases.append(
                 CaseLocalMapper(
@@ -66,8 +66,7 @@ class PathsMapper(BaseMapper):
         if not os.path.isdir(abs_case_path):
             raise HTTPException(status_code=404, detail=f"Case '{case_id}' not found")
 
-        # If the case directory itself is a supported format (e.g. DICOM),
-        # it is the slide - return it directly
+        # If the case directory is itself a slide (e.g. DICOM), return it directly.
         if is_supported_format(abs_case_path):
             slide_id = case_id
             addresses = local_mode_collect_secondary_files_v3(abs_case_path, slide_id, slide_id, self.data_dir)
@@ -82,8 +81,6 @@ class PathsMapper(BaseMapper):
         slides = []
         for file in sorted(os.listdir(abs_case_path)):
             absfile = os.path.join(abs_case_path, file)
-            if not os.path.isfile(absfile):
-                continue
             if is_supported_format(absfile):
                 slide_id = f"{case_id}/{file}"
                 addresses = local_mode_collect_secondary_files_v3(absfile, slide_id, slide_id, self.data_dir)

--- a/wsi_service/paths_mapper.py
+++ b/wsi_service/paths_mapper.py
@@ -38,11 +38,16 @@ class PathsMapper(BaseMapper):
             case_id = f"{context}/{d}"
             case_path = os.path.join(abs_context_path, d)
 
-            slide_ids = []
-            for file in os.listdir(case_path):
-                absfile = os.path.join(case_path, file)
-                if os.path.isfile(absfile) and is_supported_format(absfile):
-                    slide_ids.append(f"{case_id}/{file}")
+            # If the directory itself is a supported format (e.g. DICOM),
+            # treat it as a slide rather than a case directory
+            if is_supported_format(case_path):
+                slide_ids = [case_id]
+            else:
+                slide_ids = []
+                for file in os.listdir(case_path):
+                    absfile = os.path.join(case_path, file)
+                    if (os.path.isfile(absfile) or os.path.isdir(absfile)) and is_supported_format(absfile):
+                        slide_ids.append(f"{case_id}/{file}")
 
             cases.append(
                 CaseLocalMapper(
@@ -60,6 +65,19 @@ class PathsMapper(BaseMapper):
 
         if not os.path.isdir(abs_case_path):
             raise HTTPException(status_code=404, detail=f"Case '{case_id}' not found")
+
+        # If the case directory itself is a supported format (e.g. DICOM),
+        # it is the slide - return it directly
+        if is_supported_format(abs_case_path):
+            slide_id = case_id
+            addresses = local_mode_collect_secondary_files_v3(abs_case_path, slide_id, slide_id, self.data_dir)
+            return [
+                SlideLocalMapper(
+                    id=slide_id,
+                    local_id=os.path.basename(abs_case_path),
+                    slide_storage=SlideStorage(slide_id=slide_id, storage_type="fs", storage_addresses=addresses),
+                )
+            ]
 
         slides = []
         for file in sorted(os.listdir(abs_case_path)):

--- a/wsi_service_base_plugins/wsidicom/wsi_service_plugin_wsidicom/__init__.py
+++ b/wsi_service_base_plugins/wsidicom/wsi_service_plugin_wsidicom/__init__.py
@@ -8,7 +8,7 @@ def is_supported(filepath):
     if os.path.isfile(filepath):
         return False
     else:
-        return any(list(pathlib.Path(filepath).glob("*.dcm")))
+        return any(pathlib.Path(filepath).glob("*.dcm"))
 
 
 async def open(filepath):

--- a/wsi_service_base_plugins/wsidicom/wsi_service_plugin_wsidicom/__init__.py
+++ b/wsi_service_base_plugins/wsidicom/wsi_service_plugin_wsidicom/__init__.py
@@ -5,11 +5,10 @@ from wsi_service_plugin_wsidicom.slide import Slide
 
 
 def is_supported(filepath):
-    return False # todo disabled to test bioformats
-    # if os.path.isfile(filepath):
-    #     return False
-    # else:
-    #     return any(list(pathlib.Path(filepath).glob("*.dcm")))
+    if os.path.isfile(filepath):
+        return False
+    else:
+        return any(list(pathlib.Path(filepath).glob("*.dcm")))
 
 
 async def open(filepath):

--- a/wsi_service_base_plugins/wsidicom/wsi_service_plugin_wsidicom/slide.py
+++ b/wsi_service_base_plugins/wsidicom/wsi_service_plugin_wsidicom/slide.py
@@ -126,7 +126,7 @@ class Slide(BaseSlide):
         return original_levels
 
     def __get_pixel_size(self):
-        mpp = self.dicom_slide.levels.get_level(0).mpp
+        mpp = self.dicom_slide.levels[0].mpp
         return SlidePixelSizeNm(x=1000.0 * mpp.width, y=1000.0 * mpp.height)
 
     def __get_tile_extent(self):
@@ -135,7 +135,7 @@ class Slide(BaseSlide):
 
         # some tiles can have an unequal tile height and width that can cause problems in the slide viewer
         # since the tile route is soley used for viewing, we provide the default tile width and height
-        base_level = self.dicom_slide.levels.get_level(0)
+        base_level = self.dicom_slide.levels[0]
         temp_height = base_level.tile_size.height
         temp_width = base_level.tile_size.width
 
@@ -147,7 +147,7 @@ class Slide(BaseSlide):
 
     def __get_slide_info_dicom(self):
         try:
-            base_level = self.dicom_slide.levels.get_level(0)
+            base_level = self.dicom_slide.levels[0]
             levels = self.__get_levels_dicom()
             slide_info = SlideInfo(
                 id="",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DICOM-format folders are now correctly detected and no longer misclassified as regular case collections.

* **New Behavior**
  * When a case path itself is a supported-format folder, it is treated as a single slide and its associated files are collected.

* **Refactor**
  * Simplified slide-level operations to improve accuracy of reported pixel size and tile extent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->